### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,7 @@
 name: Create Release PR
+permissions:
+  contents: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/myjdownloader-card/security/code-scanning/4](https://github.com/Nyaran/myjdownloader-card/security/code-scanning/4)

To resolve the issue, add a `permissions` block to the workflow, either at the root level (applies to all jobs unless overridden) or specifically to the `release` job. The `create-pull-request` action only requires `contents: write` and `pull-requests: write` to create pull requests, and all other steps can be completed with read-only or minimal permissions. The best practice is to specify only the minimum required permissions; at a minimum, include `contents: read` if uncertain, but for this workflow, use:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Insert this at the root of the workflow, near the top (e.g., after `name:` or after `on:`), to explicitly restrict permissions as needed for the job. No changes to imports, methods, or functionality are needed; just the addition of this block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
