### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -10,6 +10,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   validate:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/myjdownloader-card/security/code-scanning/3](https://github.com/Nyaran/myjdownloader-card/security/code-scanning/3)

To fix the problem, you should add an explicit `permissions` key with minimal required permissions. The single best way to do this is to add `permissions: contents: read` either at the workflow root (before `jobs:` on line 13) or within the job itself. Adding it at the root will apply the restriction to all jobs (in this case, just one). Insert it directly above `jobs:` in the `.github/workflows/validate-hacs.yml` file, as shown in the line-by-line context. No imports, function changes, or further setup is required; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
