### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if:  startsWith(github.head_ref, 'release/')
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/myjdownloader-card/security/code-scanning/2](https://github.com/Nyaran/myjdownloader-card/security/code-scanning/2)

To fix the problem, add a `permissions` block at the `jobs.release` level (or at the workflow root) specifying the minimal permissions required. Since the workflow's main sensitive operation is creating a GitHub release (which requires `contents: write`), we should set `contents: write` and not grant permissions for other scopes. This block should be added directly above `runs-on` in the `release` job for clarity and direct minimal privilege.

No changes to code logic are needed—just a configuration addition in the YAML file within the `release` job definition, between `release:` and `runs-on:`. No new methods, imports, or variables are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
