### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test
-
+permissions:
+  contents: read
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/myjdownloader-card/security/code-scanning/1](https://github.com/Nyaran/myjdownloader-card/security/code-scanning/1)

To fix this issue, an explicit `permissions` block should be added to the workflow file specifying the minimum required permissions for the workflow to function. As the workflow described only checks out code, sets up Node.js, installs dependencies, and runs the linter (with test and coverage steps commented out), it does not require write access to repository contents or other resources. Therefore, adding `permissions: contents: read` at the root of the workflow file is the most straightforward way to limit the GITHUB_TOKEN permissions as recommended. This block should be placed directly under the workflow `name` and above the `on` key, spanning lines 2-3.

No extra imports or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
